### PR TITLE
Use DEFAULT_PATTERN for env list command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,8 @@ jobs:
           else
           # simple version are created manually from code edits.
           echo "This is a simple version: $VERSION, we have released it, converting into next dev."
-          hatch version patch
+          #hatch version patch
+          hatch version minor # TODO: we are using MINOR and increasing minor versions until v1.0
           hatch version dev
           fi
           NEW_VERSION=`hatch version`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,17 +45,17 @@ jobs:
           # current version
           VERSION=`hatch version`
           if [[ $VERSION == *dev* ]]; then
-          echo "This is a dev version: $VERSION"
-          hatch version dev
+              echo "This is a dev version: $VERSION"
+              hatch version dev
           elif [[ $VERSION == *rc* ]]; then
-          echo "This is a RC version: $VERSION,\n only use dev and release ones"
-          exit 1
+              echo "This is a RC version: $VERSION,\n only use dev and release ones"
+              exit 1
           else
-          # simple version are created manually from code edits.
-          echo "This is a simple version: $VERSION, we have released it, converting into next dev."
-          #hatch version patch
-          hatch version minor # TODO: we are using MINOR and increasing minor versions until v1.0
-          hatch version dev
+              # simple version are created manually from code edits.
+              echo "This is a simple version: $VERSION, we have released it, converting into next dev."
+              #hatch version patch
+              hatch version minor # TODO: we are using MINOR and increasing minor versions until v1.0
+              hatch version dev
           fi
           NEW_VERSION=`hatch version`
           git add src/hckr/__about__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,10 @@ dependencies = [
     "psycopg2-binary", # for Postgres
     "pymysql", # for MySQL
 #    "sqlite", # for SQLITE
-    "snowflake-sqlalchemy",  # For Snowflake
+    "snowflake-sqlalchemy",  # For Snowflake,
+
+    # Error and debugging
+    "sentry-sdk"
 ]
 
 [project.urls]

--- a/src/hckr/__about__.py
+++ b/src/hckr/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present Ashish Patel <ashishpatel0720@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.4.1.dev0"
+__version__ = "0.5.0"

--- a/src/hckr/__about__.py
+++ b/src/hckr/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present Ashish Patel <ashishpatel0720@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.5.0"
+__version__ = "0.5.0.dev0"

--- a/src/hckr/cli/__init__.py
+++ b/src/hckr/cli/__init__.py
@@ -23,17 +23,11 @@ from ..__about__ import __version__
 from ..cli.cron import cron
 from ..cli.crypto import crypto
 from ..cli.hash import hash
-from ..utils.CliUtils import check_update, Info
+from ..utils.CliUtils import check_update, Info, LOGGING_LEVELS
 from ..utils.MessageUtils import warning
 
-LOGGING_LEVELS = {
-    0: logging.NOTSET,
-    # 1: logging.ERROR,
-    # 2: logging.WARN,
-    1: logging.INFO,
-    2: logging.DEBUG,
-}  #: a mapping of `verbose` option counts to logging levels
 
+# sentry logging and monitoring
 CliUtils.sentry_init()
 
 # pass_info is a decorator for functions that pass 'Info' objects.

--- a/src/hckr/cli/__init__.py
+++ b/src/hckr/cli/__init__.py
@@ -13,6 +13,7 @@ from hckr.cli.env import env
 from hckr.cli.k8s.context import context
 from hckr.cli.k8s.namespace import namespace
 from hckr.cli.k8s.pod import pod
+from hckr.utils import CliUtils
 from .crypto.fernet import fernet
 from .data import data
 from .info import info
@@ -22,7 +23,7 @@ from ..__about__ import __version__
 from ..cli.cron import cron
 from ..cli.crypto import crypto
 from ..cli.hash import hash
-from ..utils.CliUtils import check_update
+from ..utils.CliUtils import check_update, Info
 from ..utils.MessageUtils import warning
 
 LOGGING_LEVELS = {
@@ -33,15 +34,7 @@ LOGGING_LEVELS = {
     2: logging.DEBUG,
 }  #: a mapping of `verbose` option counts to logging levels
 
-
-# Define a format for the console handler
-class Info:
-    """An information object to pass data between CLI functions."""
-
-    def __init__(self):  # Note: This object must have an empty constructor.
-        """Create a new instance."""
-        self.verbose: int = 0
-
+CliUtils.sentry_init()
 
 # pass_info is a decorator for functions that pass 'Info' objects.
 pass_info = click.make_pass_decorator(Info, ensure=True)

--- a/src/hckr/cli/env.py
+++ b/src/hckr/cli/env.py
@@ -1,9 +1,10 @@
 import os
+from filecmp import DEFAULT_IGNORES
 
 import click
 
 from ..utils import MessageUtils
-from ..utils.EnvUtils import list_env, set_env
+from ..utils.EnvUtils import list_env, set_env, DEFAULT_PATTERN
 from ..utils.MessageUtils import PSuccess, PError
 
 
@@ -84,7 +85,7 @@ def get(variable):
 
 
 @env.command("list")
-@click.option("-p", "--pattern", required=False, default=".*")
+@click.option("-p", "--pattern", required=False, default=DEFAULT_PATTERN)
 @click.option("-i", "--ignore-case", is_flag=True, help="Ignore case distinctions.")
 def env_list(pattern, ignore_case):
     """
@@ -113,5 +114,10 @@ def env_list(pattern, ignore_case):
 
     **Command Reference**:
     """
-    MessageUtils.info("Listing all environment variables")
+    if pattern == DEFAULT_PATTERN:
+        MessageUtils.info("Listing all environment variables")
+    else:
+        MessageUtils.info(
+            f"Listing environment variables, filtering with regex pattern '[green]{pattern}[/green]'"
+        )
     list_env(pattern, ignore_case)

--- a/src/hckr/cli/env.py
+++ b/src/hckr/cli/env.py
@@ -1,5 +1,4 @@
 import os
-from filecmp import DEFAULT_IGNORES
 
 import click
 

--- a/src/hckr/utils/CliUtils.py
+++ b/src/hckr/utils/CliUtils.py
@@ -57,3 +57,25 @@ def check_update(show_no_update=False):
         success(
             f"Success: You are using latest version {colored(__version__, 'magenta')}"
         )
+
+
+def sentry_init():
+    import sentry_sdk
+    sentry_sdk.init(
+        dsn="https://b549c324ba6054fc68c4e3cd3bb146e4@o4507910058213376.ingest.us.sentry.io/4507910060572672",
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for tracing.
+        traces_sample_rate=1.0,
+        # Set profiles_sample_rate to 1.0 to profile 100%
+        # of sampled transactions.
+        # We recommend adjusting this value in production.
+        profiles_sample_rate=1.0,
+    )
+
+# Define a format for the console handler
+class Info:
+    """An information object to pass data between CLI functions."""
+
+    def __init__(self):  # Note: This object must have an empty constructor.
+        """Create a new instance."""
+        self.verbose: int = 0

--- a/src/hckr/utils/CliUtils.py
+++ b/src/hckr/utils/CliUtils.py
@@ -19,6 +19,7 @@ LOGGING_LEVELS = {
     2: logging.DEBUG,
 }  #: a mapping of `verbose` option counts to logging levels
 
+
 # Define a format for the console handler
 class Info:
     """An information object to pass data between CLI functions."""
@@ -79,6 +80,7 @@ def check_update(show_no_update=False):
 
 def sentry_init():
     import sentry_sdk
+
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         # Set traces_sample_rate to 1.0 to capture 100%

--- a/src/hckr/utils/CliUtils.py
+++ b/src/hckr/utils/CliUtils.py
@@ -10,6 +10,23 @@ from ..__about__ import __version__
 import platform
 
 
+LOGGING_LEVELS = {
+    0: logging.NOTSET,
+    # 1: logging.ERROR,
+    # 2: logging.WARN,
+    1: logging.INFO,
+    2: logging.DEBUG,
+}  #: a mapping of `verbose` option counts to logging levels
+
+# Define a format for the console handler
+class Info:
+    """An information object to pass data between CLI functions."""
+
+    def __init__(self):  # Note: This object must have an empty constructor.
+        """Create a new instance."""
+        self.verbose: int = 0
+
+
 def check_latest_version():
     current_version = __version__
     try:
@@ -71,11 +88,3 @@ def sentry_init():
         # We recommend adjusting this value in production.
         profiles_sample_rate=1.0,
     )
-
-# Define a format for the console handler
-class Info:
-    """An information object to pass data between CLI functions."""
-
-    def __init__(self):  # Note: This object must have an empty constructor.
-        """Create a new instance."""
-        self.verbose: int = 0

--- a/src/hckr/utils/CliUtils.py
+++ b/src/hckr/utils/CliUtils.py
@@ -6,6 +6,7 @@ from packaging import version
 from rich.panel import Panel
 
 from .MessageUtils import colored, success, warning
+from .config.Constants import SENTRY_DSN
 from ..__about__ import __version__
 import platform
 
@@ -79,7 +80,7 @@ def check_update(show_no_update=False):
 def sentry_init():
     import sentry_sdk
     sentry_sdk.init(
-        dsn="https://b549c324ba6054fc68c4e3cd3bb146e4@o4507910058213376.ingest.us.sentry.io/4507910060572672",
+        dsn=SENTRY_DSN,
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for tracing.
         traces_sample_rate=1.0,

--- a/src/hckr/utils/EnvUtils.py
+++ b/src/hckr/utils/EnvUtils.py
@@ -5,6 +5,8 @@ import re
 from . import MessageUtils
 from .MessageUtils import PError, PSuccess, PWarn
 
+DEFAULT_PATTERN = ".*"
+
 
 def list_env(pattern, ignore_case):
     """List all environment variables, optionally filtering by a pattern."""

--- a/src/hckr/utils/config/Constants.py
+++ b/src/hckr/utils/config/Constants.py
@@ -47,3 +47,6 @@ DB_SCHEMA = "schema"
 DB_ACCOUNT = "account"
 DB_ROLE = "role"
 DB_WAREHOUSE = "warehouse"
+
+# SENTRY
+SENTRY_DSN = "https://b549c324ba6054fc68c4e3cd3bb146e4@o4507910058213376.ingest.us.sentry.io/4507910060572672"


### PR DESCRIPTION
Updated the env list command to use a DEFAULT_PATTERN constant for default regex filtering. Adjusted the message output to indicate when a custom pattern is used for filtering environment variables.